### PR TITLE
FIX: Inconsistent shape checking in unit test

### DIFF
--- a/src/sirrs/sir.rs
+++ b/src/sirrs/sir.rs
@@ -164,11 +164,11 @@ mod tests {
             model.i_popf.shape(),
         );
         assert_eq!(
-            (model.r_popf.nrows(), model.r_popf.ncols()),
+            model.r_popf.shape(),
             (model.length, 1),
             "Bad r_popf dimensions, expected {:?} got {:?}.",
             (model.length, 1),
-            (model.r_popf.nrows(), model.r_popf.ncols()),
+            model.r_popf.shape(),
         );
         assert_eq!(
             model.s_popf[(0, 0)],


### PR DESCRIPTION
# Proposed changes

Replace two errant occurrences of `(*.nrows(), *.ncols())` with `*.shape()`.