### PR TITLE
Feat: Add configure methods to streaming constructors

### DIFF
--- a/src/sirrs/dismod.rs
+++ b/src/sirrs/dismod.rs
@@ -68,9 +68,7 @@ impl Model {
         chi: f64,
         omega: f64,
     ) -> &mut Self {
-        let n_steps = (length.to_f64().unwrap() / step_size)
-            .to_usize()
-            .unwrap();
+        let n_steps = (length.to_f64().unwrap() / step_size).to_usize().unwrap();
         self.length = length;
         self.step_size = step_size;
         self.c_init = c_init;
@@ -215,7 +213,7 @@ mod tests {
     #[test]
     fn test_new() {
         let model = Model::new();
-         assert_eq!(
+        assert_eq!(
             model.length, 0,
             "Bad length, expected 0 got {}",
             model.length
@@ -225,11 +223,7 @@ mod tests {
             "Bad c_init, expected 0.0 got {}",
             model.c_init,
         );
-        assert_eq!(
-            model.iota, 0.0,
-            "Bad iota, expected 0.0 got {}",
-            model.iota,
-        );
+        assert_eq!(model.iota, 0.0, "Bad iota, expected 0.0 got {}", model.iota,);
         assert_eq!(model.rho, 0.0, "Bad rho, expected 0.0 got {}", model.rho);
         assert_eq!(model.chi, 0.0, "Bad chi, expected 0.0 got {}", model.chi);
         assert_eq!(
@@ -254,15 +248,7 @@ mod tests {
     #[test]
     fn test_configure() {
         let mut model = Model::new();
-        model.configure(
-            10,
-            1.0,
-            0.01,
-            0.01,
-            0.02,
-            0.03,
-            0.04,
-        );
+        model.configure(10, 1.0, 0.01, 0.01, 0.02, 0.03, 0.04);
         let n_steps = (model.length.to_f64().unwrap() / model.step_size)
             .to_usize()
             .unwrap();
@@ -305,15 +291,7 @@ mod tests {
     #[test]
     fn test_init_popf() {
         let mut model = Model::new();
-        model.configure(
-            10,
-            1.0,
-            0.01,
-            0.01,
-            0.02,
-            0.03,
-            0.04,
-        );
+        model.configure(10, 1.0, 0.01, 0.01, 0.02, 0.03, 0.04);
         model.init_popf();
         assert_eq!(
             model.s.shape(),
@@ -362,15 +340,7 @@ mod tests {
     #[test]
     fn test_run_euler() {
         let mut model = Model::new();
-        model.configure(
-            10,
-            1.0,
-            0.01,
-            0.01,
-            0.02,
-            0.03,
-            0.04,
-        );
+        model.configure(10, 1.0, 0.01, 0.01, 0.02, 0.03, 0.04);
         model.init_popf();
         model.run_euler();
         for t in 1..model.length {
@@ -414,75 +384,91 @@ mod tests {
     #[test]
     fn test_init_h() {
         let mut model = Model::new();
-        model.configure(
-            10,
-            1.0,
-            0.01,
-            0.01,
-            0.02,
-            0.03,
-            0.04,
-        );
+        model.configure(10, 1.0, 0.01, 0.01, 0.02, 0.03, 0.04);
         let h = model.init_h();
-        assert!(h.len() == 4, "Bad h initialization, expected 4 items, got {}", h.len());
-        assert!(h[0] == model.step_size / 2.0, "h[0] is not equal to model.step_size/2, got {}", h[0]);
-        assert!(h[1] == model.step_size / 2.0, "h[1] is not equal to model.step_size/2, got {}", h[1]);
-        assert!(h[2] == model.step_size, "h[2] is not equal to model.step_size, got {}", h[2]);
-        assert!(h[3] == model.step_size, "h[3] is not equal to model.step_size, got {}", h[3]);
+        assert!(
+            h.len() == 4,
+            "Bad h initialization, expected 4 items, got {}",
+            h.len()
+        );
+        assert!(
+            h[0] == model.step_size / 2.0,
+            "h[0] is not equal to model.step_size/2, got {}",
+            h[0]
+        );
+        assert!(
+            h[1] == model.step_size / 2.0,
+            "h[1] is not equal to model.step_size/2, got {}",
+            h[1]
+        );
+        assert!(
+            h[2] == model.step_size,
+            "h[2] is not equal to model.step_size, got {}",
+            h[2]
+        );
+        assert!(
+            h[3] == model.step_size,
+            "h[3] is not equal to model.step_size, got {}",
+            h[3]
+        );
     }
 
     #[test]
     fn test_init_y() {
         let mut model = Model::new();
-        model.configure(
-            10,
-            1.0,
-            0.01,
-            0.01,
-            0.02,
-            0.03,
-            0.04,
-        );
+        model.configure(10, 1.0, 0.01, 0.01, 0.02, 0.03, 0.04);
         let y = model.init_y();
-        assert!(y.len() == 5, "Bad y initialization, expected 5 items, got {}", y.len());
+        assert!(
+            y.len() == 5,
+            "Bad y initialization, expected 5 items, got {}",
+            y.len()
+        );
         for i in 0..5 {
-            assert!(y[i].s == 0.0, "y[{}].s is not equal to 0.0, got {}", i, y[i].s);
-            assert!(y[i].c == 0.0, "y[{}].c is not equal to 0.0, got {}", i, y[i].c);
+            assert!(
+                y[i].s == 0.0,
+                "y[{}].s is not equal to 0.0, got {}",
+                i,
+                y[i].s
+            );
+            assert!(
+                y[i].c == 0.0,
+                "y[{}].c is not equal to 0.0, got {}",
+                i,
+                y[i].c
+            );
         }
     }
 
     #[test]
     fn test_init_k() {
         let mut model = Model::new();
-        model.configure(
-            10,
-            1.0,
-            0.01,
-            0.01,
-            0.02,
-            0.03,
-            0.04,
-        );
+        model.configure(10, 1.0, 0.01, 0.01, 0.02, 0.03, 0.04);
         let k = model.init_k();
-        assert!(k.len() == 5, "Bad y initialization, expected 5 items, got {}", k.len());
+        assert!(
+            k.len() == 5,
+            "Bad y initialization, expected 5 items, got {}",
+            k.len()
+        );
         for i in 0..5 {
-            assert!(k[i].s == 0.0, "k[{}].s is not equal to 0.0, got {}", i, k[i].s);
-            assert!(k[i].c == 0.0, "k[{}].c is not equal to 0.0, got {}", i, k[i].c);
+            assert!(
+                k[i].s == 0.0,
+                "k[{}].s is not equal to 0.0, got {}",
+                i,
+                k[i].s
+            );
+            assert!(
+                k[i].c == 0.0,
+                "k[{}].c is not equal to 0.0, got {}",
+                i,
+                k[i].c
+            );
         }
     }
 
     #[test]
     fn test_run_rk4() {
         let mut model = Model::new();
-        model.configure(
-            10,
-            1.0,
-            0.01,
-            0.01,
-            0.02,
-            0.03,
-            0.04,
-        );
+        model.configure(10, 1.0, 0.01, 0.01, 0.02, 0.03, 0.04);
         model.init_popf();
         model.run_rk4();
         let h = model.step_size;

--- a/src/sirrs/sir.rs
+++ b/src/sirrs/sir.rs
@@ -68,9 +68,7 @@ impl Model {
         removal_rate: f64,
         recovery_rate: f64,
     ) -> &mut Self {
-        let n_steps = (length.to_f64().unwrap() / step_size)
-            .to_usize()
-            .unwrap();
+        let n_steps = (length.to_f64().unwrap() / step_size).to_usize().unwrap();
         self.length = length;
         self.step_size = step_size;
         self.i_popf_init = i_popf_init;
@@ -323,15 +321,7 @@ mod tests {
     #[test]
     fn test_configure() {
         let mut model = Model::new();
-        model.configure(
-            10,
-            1.0,
-            0.01,
-            0.0,
-            0.02,
-            0.03,
-            0.04,
-        );
+        model.configure(10, 1.0, 0.01, 0.0, 0.02, 0.03, 0.04);
         let n_steps = (model.length.to_f64().unwrap() / model.step_size)
             .to_usize()
             .unwrap();
@@ -388,15 +378,7 @@ mod tests {
     #[test]
     fn test_init_popf() {
         let mut model = Model::new();
-        model.configure(
-            10,
-            1.0,
-            0.01,
-            0.0,
-            0.02,
-            0.03,
-            0.04,
-        );
+        model.configure(10, 1.0, 0.01, 0.0, 0.02, 0.03, 0.04);
         model.init_popf();
         assert_eq!(
             model.s_popf.shape(),
@@ -465,15 +447,7 @@ mod tests {
     #[test]
     fn test_run_euler() {
         let mut model = Model::new();
-        model.configure(
-            10,
-            1.0,
-            0.01,
-            0.0,
-            0.02,
-            0.03,
-            0.04,
-        );
+        model.configure(10, 1.0, 0.01, 0.0, 0.02, 0.03, 0.04);
         model.init_popf();
         model.run_euler();
         let h = model.step_size;
@@ -536,15 +510,7 @@ mod tests {
     #[test]
     fn test_init_h() {
         let mut model = Model::new();
-        model.configure(
-            10,
-            1.0,
-            0.01,
-            0.0,
-            0.02,
-            0.03,
-            0.04,
-        );
+        model.configure(10, 1.0, 0.01, 0.0, 0.02, 0.03, 0.04);
         let h = model.init_h();
         assert!(
             h.len() == 4,
@@ -576,15 +542,7 @@ mod tests {
     #[test]
     fn test_init_y() {
         let mut model = Model::new();
-        model.configure(
-            10,
-            1.0,
-            0.01,
-            0.0,
-            0.02,
-            0.03,
-            0.04,
-        );
+        model.configure(10, 1.0, 0.01, 0.0, 0.02, 0.03, 0.04);
         let y = model.init_y();
         assert!(
             y.len() == 5,
@@ -616,15 +574,7 @@ mod tests {
     #[test]
     fn test_init_k() {
         let mut model = Model::new();
-        model.configure(
-            10,
-            1.0,
-            0.01,
-            0.0,
-            0.02,
-            0.03,
-            0.04,
-        );
+        model.configure(10, 1.0, 0.01, 0.0, 0.02, 0.03, 0.04);
         let k = model.init_k();
         assert!(
             k.len() == 5,
@@ -656,15 +606,7 @@ mod tests {
     #[test]
     fn test_run_rk4() {
         let mut model = Model::new();
-        model.configure(
-            10,
-            1.0,
-            0.01,
-            0.0,
-            0.02,
-            0.03,
-            0.04,
-        );
+        model.configure(10, 1.0, 0.01, 0.0, 0.02, 0.03, 0.04);
         model.init_popf();
         model.run_rk4();
         let h = model.step_size;

--- a/src/sirrs/sir.rs
+++ b/src/sirrs/sir.rs
@@ -42,7 +42,24 @@ pub struct Model {
 
 impl Model {
     /// Create a new model object.
-    pub fn new(
+    pub fn new() -> Self {
+        return Self {
+            length: 0,
+            step_size: 0.0,
+            i_popf_init: 0.0,
+            r_popf_init: 0.0,
+            incidence_rate: 0.0,
+            removal_rate: 0.0,
+            recovery_rate: 0.0,
+            s_popf: Mat::new(),
+            i_popf: Mat::new(),
+            r_popf: Mat::new(),
+        };
+    }
+
+    /// Configure model parameters.
+    pub fn configure(
+        &mut self,
         length: usize,
         step_size: f64,
         i_popf_init: f64,
@@ -50,34 +67,27 @@ impl Model {
         incidence_rate: f64,
         removal_rate: f64,
         recovery_rate: f64,
-        s_popf: Mat<f64>,
-        i_popf: Mat<f64>,
-        r_popf: Mat<f64>,
-    ) -> Self {
-        return Model {
-            length,
-            step_size,
-            i_popf_init,
-            r_popf_init,
-            incidence_rate,
-            removal_rate,
-            recovery_rate,
-            s_popf,
-            i_popf,
-            r_popf,
-        };
+    ) -> &mut Self {
+        let n_steps = (length.to_f64().unwrap() / step_size)
+            .to_usize()
+            .unwrap();
+        self.length = length;
+        self.step_size = step_size;
+        self.i_popf_init = i_popf_init;
+        self.r_popf_init = r_popf_init;
+        self.incidence_rate = incidence_rate;
+        self.removal_rate = removal_rate;
+        self.recovery_rate = recovery_rate;
+        self.s_popf = Mat::zeros(n_steps, 1);
+        self.i_popf = Mat::zeros(n_steps, 1);
+        self.r_popf = Mat::zeros(n_steps, 1);
+        return self;
     }
 
     /// Initialize population fractions. Creates arrays of length `self.length`
     /// to store the population fractions at each index and sets the 0th index
     /// of each equal to the corresponding initial population fraction.
     pub fn init_popf(&mut self) -> &mut Model {
-        let n_steps = (self.length.to_f64().unwrap() / self.step_size)
-            .to_usize()
-            .unwrap();
-        self.s_popf = Mat::zeros(n_steps, 1);
-        self.i_popf = Mat::zeros(n_steps, 1);
-        self.r_popf = Mat::zeros(n_steps, 1);
         let s_init = 1.0 - self.i_popf_init - self.r_popf_init; // Population fractions must sum to 1.
         self.s_popf[(0, 0)] = s_init;
         self.i_popf[(0, 0)] = self.i_popf_init;
@@ -258,8 +268,62 @@ mod tests {
     use faer::{Mat, traits::num_traits::ToPrimitive};
 
     #[test]
-    fn test_init_model() {
-        let model = Model::new(
+    fn test_new() {
+        let model = Model::new();
+        assert_eq!(
+            model.length, 0,
+            "Bad length, expected 0 got {}",
+            model.length
+        );
+        assert_eq!(
+            model.i_popf_init, 0.0,
+            "Bad i_popf_init, expected 0.0 got {}",
+            model.i_popf_init,
+        );
+        assert_eq!(
+            model.r_popf_init, 0.0,
+            "Bad r_popf_init, expected 0.0 got {}",
+            model.r_popf_init,
+        );
+        assert_eq!(
+            model.incidence_rate, 0.0,
+            "Bad incidence_rate, expected 0.0 got {}",
+            model.incidence_rate,
+        );
+        assert_eq!(
+            model.removal_rate, 0.0,
+            "Bad , expected 0.0 got {}",
+            model.removal_rate,
+        );
+        assert_eq!(
+            model.recovery_rate, 0.0,
+            "Bad , expected 0.0 got {}",
+            model.recovery_rate,
+        );
+        assert_eq!(
+            model.s_popf,
+            Mat::new(),
+            "Bad , expected Mat::new() got {:?}",
+            model.s_popf,
+        );
+        assert_eq!(
+            model.i_popf,
+            Mat::new(),
+            "Bad , expected Mat::new() got {:?}",
+            model.i_popf,
+        );
+        assert_eq!(
+            model.r_popf,
+            Mat::new(),
+            "Bad , expected Mat::new() got {:?}",
+            model.r_popf,
+        );
+    }
+
+    #[test]
+    fn test_configure() {
+        let mut model = Model::new();
+        model.configure(
             10,
             1.0,
             0.01,
@@ -267,10 +331,10 @@ mod tests {
             0.02,
             0.03,
             0.04,
-            Mat::new(),
-            Mat::new(),
-            Mat::new(),
         );
+        let n_steps = (model.length.to_f64().unwrap() / model.step_size)
+            .to_usize()
+            .unwrap();
         assert_eq!(
             model.length, 10,
             "Bad length, expected 10 got {}",
@@ -303,27 +367,28 @@ mod tests {
         );
         assert_eq!(
             model.s_popf,
-            Mat::new(),
-            "Bad , expected Mat::new() got {:?}",
+            Mat::zeros(n_steps, 1),
+            "Bad , expected Mat::zeros(n_steps, 1) got {:?}",
             model.s_popf,
         );
         assert_eq!(
             model.i_popf,
-            Mat::new(),
-            "Bad , expected Mat::new() got {:?}",
+            Mat::zeros(n_steps, 1),
+            "Bad , expected Mat::zeros(n_steps, 1) got {:?}",
             model.i_popf,
         );
         assert_eq!(
             model.r_popf,
-            Mat::new(),
-            "Bad , expected Mat::new() got {:?}",
+            Mat::zeros(n_steps, 1),
+            "Bad , expected Mat::zeros(n_steps, 1) got {:?}",
             model.r_popf,
         );
     }
 
     #[test]
     fn test_init_popf() {
-        let mut model = Model::new(
+        let mut model = Model::new();
+        model.configure(
             10,
             1.0,
             0.01,
@@ -331,9 +396,6 @@ mod tests {
             0.02,
             0.03,
             0.04,
-            Mat::new(),
-            Mat::new(),
-            Mat::new(),
         );
         model.init_popf();
         assert_eq!(
@@ -402,7 +464,8 @@ mod tests {
 
     #[test]
     fn test_run_euler() {
-        let mut model = Model::new(
+        let mut model = Model::new();
+        model.configure(
             10,
             1.0,
             0.01,
@@ -410,9 +473,6 @@ mod tests {
             0.02,
             0.03,
             0.04,
-            Mat::new(),
-            Mat::new(),
-            Mat::new(),
         );
         model.init_popf();
         model.run_euler();
@@ -475,7 +535,8 @@ mod tests {
 
     #[test]
     fn test_init_h() {
-        let model = Model::new(
+        let mut model = Model::new();
+        model.configure(
             10,
             1.0,
             0.01,
@@ -483,9 +544,6 @@ mod tests {
             0.02,
             0.03,
             0.04,
-            Mat::new(),
-            Mat::new(),
-            Mat::new(),
         );
         let h = model.init_h();
         assert!(
@@ -517,7 +575,8 @@ mod tests {
 
     #[test]
     fn test_init_y() {
-        let model = Model::new(
+        let mut model = Model::new();
+        model.configure(
             10,
             1.0,
             0.01,
@@ -525,9 +584,6 @@ mod tests {
             0.02,
             0.03,
             0.04,
-            Mat::new(),
-            Mat::new(),
-            Mat::new(),
         );
         let y = model.init_y();
         assert!(
@@ -559,7 +615,8 @@ mod tests {
 
     #[test]
     fn test_init_k() {
-        let model = Model::new(
+        let mut model = Model::new();
+        model.configure(
             10,
             1.0,
             0.01,
@@ -567,9 +624,6 @@ mod tests {
             0.02,
             0.03,
             0.04,
-            Mat::new(),
-            Mat::new(),
-            Mat::new(),
         );
         let k = model.init_k();
         assert!(
@@ -601,7 +655,8 @@ mod tests {
 
     #[test]
     fn test_run_rk4() {
-        let mut model = Model::new(
+        let mut model = Model::new();
+        model.configure(
             10,
             1.0,
             0.01,
@@ -609,9 +664,6 @@ mod tests {
             0.02,
             0.03,
             0.04,
-            Mat::new(),
-            Mat::new(),
-            Mat::new(),
         );
         model.init_popf();
         model.run_rk4();

--- a/tests/test_dismod.rs
+++ b/tests/test_dismod.rs
@@ -3,15 +3,7 @@ use sirrs::dismod::Model;
 #[test]
 fn dismod_init_popf() {
     let mut model = Model::new();
-    model.configure(
-        10,
-        1.0,
-        0.01,
-        0.01,
-        0.02,
-        0.03,
-        0.04,
-    );
+    model.configure(10, 1.0, 0.01, 0.01, 0.02, 0.03, 0.04);
     model.init_popf();
     assert_eq!(
         model.s.shape(),
@@ -35,18 +27,22 @@ fn dismod_init_popf() {
         model.s[(0, 0)],
     );
     assert_eq!(
-        model.c[(0, 0)], model.c_init,
+        model.c[(0, 0)],
+        model.c_init,
         "Bad c[(0, 0)] initialization value, expected {} got {}.",
-        model.c_init, model.c[(0, 0)],
+        model.c_init,
+        model.c[(0, 0)],
     );
     for t in 1..model.length {
         assert_eq!(
-            model.s[(t, 0)], 0.0,
+            model.s[(t, 0)],
+            0.0,
             "Bad s[t>0] initialization value, expected 0.0 got {}.",
             model.s[(t, 0)]
         );
         assert_eq!(
-            model.c[(t, 0)], 0.0,
+            model.c[(t, 0)],
+            0.0,
             "Bad c[t>0] initialization value, expected 0.0 got {}.",
             model.c[(t, 0)]
         );
@@ -56,15 +52,7 @@ fn dismod_init_popf() {
 #[test]
 fn dismod_run_euler() {
     let mut model = Model::new();
-    model.configure(
-        10,
-        1.0,
-        0.01,
-        0.01,
-        0.02,
-        0.03,
-        0.04,
-    );
+    model.configure(10, 1.0, 0.01, 0.01, 0.02, 0.03, 0.04);
     model.init_popf();
     model.run_euler();
     for t in 1..model.length {

--- a/tests/test_dismod.rs
+++ b/tests/test_dismod.rs
@@ -1,19 +1,17 @@
 use sirrs::dismod::Model;
-use faer::Mat;
 
 #[test]
 fn dismod_init_popf() {
-    let mut model: Model = Model {
-        length: 10,
-        step_size: 1.0,
-        c_init: 0.01,
-        iota: 0.0,
-        rho: 0.02,
-        chi: 0.03,
-        omega: 0.04,
-        s: Mat::new(),
-        c: Mat::new(),
-    };
+    let mut model = Model::new();
+    model.configure(
+        10,
+        1.0,
+        0.01,
+        0.01,
+        0.02,
+        0.03,
+        0.04,
+    );
     model.init_popf();
     assert_eq!(
         model.s.shape(),
@@ -57,17 +55,16 @@ fn dismod_init_popf() {
 
 #[test]
 fn dismod_run_euler() {
-    let mut model: Model = Model {
-        length: 10,
-        step_size: 1.0,
-        c_init: 0.01,
-        iota: 0.0,
-        rho: 0.02,
-        chi: 0.03,
-        omega: 0.04,
-        s: Mat::new(),
-        c: Mat::new(),
-    };
+    let mut model = Model::new();
+    model.configure(
+        10,
+        1.0,
+        0.01,
+        0.01,
+        0.02,
+        0.03,
+        0.04,
+    );
     model.init_popf();
     model.run_euler();
     for t in 1..model.length {

--- a/tests/test_sir.rs
+++ b/tests/test_sir.rs
@@ -3,15 +3,7 @@ use sirrs::sir::Model;
 #[test]
 fn sir_init_popf() {
     let mut model = Model::new();
-    model.configure(
-        10,
-        1.0,
-        0.01,
-        0.0,
-        0.02,
-        0.03,
-        0.04,
-    );
+    model.configure(10, 1.0, 0.01, 0.0, 0.02, 0.03, 0.04);
     model.init_popf();
     assert_eq!(
         model.s_popf.shape(),
@@ -42,28 +34,35 @@ fn sir_init_popf() {
         model.s_popf[(0, 0)]
     );
     assert_eq!(
-        model.i_popf[(0, 0)], model.i_popf_init,
+        model.i_popf[(0, 0)],
+        model.i_popf_init,
         "Bad i_popf[(0, 0)] initialization value, expected {} got {}.",
-        model.i_popf_init, model.i_popf[(0, 0)],
+        model.i_popf_init,
+        model.i_popf[(0, 0)],
     );
     assert_eq!(
-        model.r_popf[(0, 0)], model.r_popf_init,
+        model.r_popf[(0, 0)],
+        model.r_popf_init,
         "Bad r_popf[(0, 0)] initialization value, expected {} got {}.",
-        model.r_popf_init, model.r_popf[(0, 0)],
+        model.r_popf_init,
+        model.r_popf[(0, 0)],
     );
     for t in 1..model.length {
         assert_eq!(
-            model.s_popf[(t, 0)], 0.0,
+            model.s_popf[(t, 0)],
+            0.0,
             "Bad s_popf[t>0] initialization value, expected 0.0 got {}.",
             model.s_popf[(t, 0)]
         );
         assert_eq!(
-            model.i_popf[(t, 0)], 0.0,
+            model.i_popf[(t, 0)],
+            0.0,
             "Bad i_popf[t>0] initialization value, expected 0.0 got {}.",
             model.i_popf[(t, 0)]
         );
         assert_eq!(
-            model.r_popf[(t, 0)], 0.0,
+            model.r_popf[(t, 0)],
+            0.0,
             "Bad r_popf[t>0] initialization value, expected 0.0 got {}.",
             model.r_popf[(t, 0)]
         );
@@ -73,15 +72,7 @@ fn sir_init_popf() {
 #[test]
 fn sir_run_euler() {
     let mut model = Model::new();
-    model.configure(
-        10,
-        1.0,
-        0.01,
-        0.0,
-        0.02,
-        0.03,
-        0.04,
-    );
+    model.configure(10, 1.0, 0.01, 0.0, 0.02, 0.03, 0.04);
     model.init_popf();
     model.run_euler();
     for t in 1..model.length {

--- a/tests/test_sir.rs
+++ b/tests/test_sir.rs
@@ -1,20 +1,17 @@
 use sirrs::sir::Model;
-use faer::Mat;
 
 #[test]
 fn sir_init_popf() {
-    let mut model: Model = Model {
-        length: 10,
-        step_size: 1.0,
-        i_popf_init: 0.01,
-        r_popf_init: 0.0,
-        incidence_rate: 0.02,
-        removal_rate: 0.03,
-        recovery_rate: 0.04,
-        s_popf: Mat::new(),
-        i_popf: Mat::new(),
-        r_popf: Mat::new(),
-    };
+    let mut model = Model::new();
+    model.configure(
+        10,
+        1.0,
+        0.01,
+        0.0,
+        0.02,
+        0.03,
+        0.04,
+    );
     model.init_popf();
     assert_eq!(
         model.s_popf.shape(),
@@ -75,18 +72,16 @@ fn sir_init_popf() {
 
 #[test]
 fn sir_run_euler() {
-    let mut model: Model = Model {
-        length: 10,
-        step_size: 1.0,
-        i_popf_init: 0.01,
-        r_popf_init: 0.0,
-        incidence_rate: 0.02,
-        removal_rate: 0.03,
-        recovery_rate: 0.04,
-        s_popf: Mat::new(),
-        i_popf: Mat::new(),
-        r_popf: Mat::new(),
-    };
+    let mut model = Model::new();
+    model.configure(
+        10,
+        1.0,
+        0.01,
+        0.0,
+        0.02,
+        0.03,
+        0.04,
+    );
     model.init_popf();
     model.run_euler();
     for t in 1..model.length {


### PR DESCRIPTION
Move configuration from the `Model::new()` initializer into a `Model::configure()` method.

Instead of specifying parameters when creating with `Model::new()` they're specified by calling `Model::configure()` after creating the object with `Model::new()`. Example:

```rust
use sirrs::sir::Model;

let mut model = Model::new();
model.configure(
    10,   // length
    1.0,  // step_size
    0.01, // i_popf_init
    0.01, // r_popf_init
    0.02, // incidence_rate
    0.03, // removal_rate
    0.04, // recovery_rate
);
```

This simplifies construction greatly by removing the need to populate defaults and set up `Mat::zeros(...)` placeholders.