### PR TITLE
Feat: As for type conversions in calculations

### DIFF
--- a/src/sirrs/dismod.rs
+++ b/src/sirrs/dismod.rs
@@ -8,7 +8,7 @@
 //!  - C → Ro
 //!
 //! See [DisMod's latest documentation](https://dismod-at.readthedocs.io/latest/diff_eq.html#diff-eq-title).
-use faer::{Mat, traits::num_traits::ToPrimitive};
+use faer::Mat;
 
 /// Numerical integrator variables
 ///
@@ -68,7 +68,7 @@ impl Model {
         chi: f64,
         omega: f64,
     ) -> &mut Self {
-        let n_steps = (length.to_f64().unwrap() / step_size).to_usize().unwrap();
+        let n_steps = ((length as f64) / step_size).ceil() as usize;
         self.length = length;
         self.step_size = step_size;
         self.c_init = c_init;
@@ -104,10 +104,7 @@ impl Model {
     /// This solution method is very rough and only suitable for demonstration.
     pub fn run_euler(&mut self) -> &Model {
         let h = self.step_size;
-        let n = (self.length.to_f64().unwrap() / h)
-            .ceil()
-            .to_usize()
-            .unwrap();
+        let n = ((self.length as f64) / h).ceil() as usize;
         for t in 1..n - 1 {
             let ds = self.dsdt(self.s[(t, 0)], self.c[(t, 0)]);
             let dc = self.dcdt(self.s[(t, 0)], self.c[(t, 0)]);
@@ -116,7 +113,7 @@ impl Model {
             if t % 10 == 0 {
                 println!(
                     "t={:.1} s={:.6} c={:.6}",
-                    t.to_f64().unwrap() * self.step_size,
+                    (t as f64) * self.step_size,
                     self.s[(t, 0)],
                     self.c[(t, 0)],
                 );
@@ -182,10 +179,7 @@ impl Model {
     ///
     /// This method is suitable for general purposes.
     pub fn run_rk4(&mut self) -> &Model {
-        let n = (self.length.to_f64().unwrap() / self.step_size)
-            .ceil()
-            .to_usize()
-            .unwrap();
+        let n = ((self.length as f64) / self.step_size).ceil() as usize;
         for t in 0..n - 1 {
             let k = self.rk4_step(t);
             let ds = (k[1].s + (2.0 * k[2].s) + (2.0 * k[3].s) + k[4].s) * (self.step_size / 6.0);
@@ -195,7 +189,7 @@ impl Model {
             if t % 10 == 0 {
                 println!(
                     "t={:.1} s={:.6} c={:.6}",
-                    t.to_f64().unwrap() * self.step_size,
+                    (t as f64) * self.step_size,
                     self.s[(t, 0)],
                     self.c[(t, 0)],
                 );
@@ -208,7 +202,7 @@ impl Model {
 #[cfg(test)]
 mod tests {
     use crate::sirrs::dismod::Model;
-    use faer::{Mat, traits::num_traits::ToPrimitive};
+    use faer::Mat;
 
     #[test]
     fn test_new() {
@@ -249,9 +243,7 @@ mod tests {
     fn test_configure() {
         let mut model = Model::new();
         model.configure(10, 1.0, 0.01, 0.01, 0.02, 0.03, 0.04);
-        let n_steps = (model.length.to_f64().unwrap() / model.step_size)
-            .to_usize()
-            .unwrap();
+        let n_steps = ((model.length as f64) / model.step_size).ceil() as usize;
         assert_eq!(
             model.length, 10,
             "Bad length, expected 10 got {}",
@@ -472,10 +464,7 @@ mod tests {
         model.init_popf();
         model.run_rk4();
         let h = model.step_size;
-        let n = (model.length.to_f64().unwrap() / h)
-            .ceil()
-            .to_usize()
-            .unwrap();
+        let n = ((model.length as f64) / h).ceil() as usize;
         for t in 0..n - 1 {
             let mut y = model.init_y();
             let mut k = model.init_k();

--- a/src/sirrs/sir.rs
+++ b/src/sirrs/sir.rs
@@ -4,7 +4,7 @@
 //!  - S → I  
 //!  - I → R  
 //!  - R → S  
-use faer::{Mat, traits::num_traits::ToPrimitive};
+use faer::Mat;
 
 /// Numerical integrator variables
 ///
@@ -68,7 +68,7 @@ impl Model {
         removal_rate: f64,
         recovery_rate: f64,
     ) -> &mut Self {
-        let n_steps = (length.to_f64().unwrap() / step_size).to_usize().unwrap();
+        let n_steps = ((length as f64) / step_size).ceil() as usize;
         self.length = length;
         self.step_size = step_size;
         self.i_popf_init = i_popf_init;
@@ -112,10 +112,7 @@ impl Model {
     /// This solution method is very rough and only suitable for demonstration.
     pub fn run_euler(&mut self) -> &Model {
         let h = self.step_size;
-        let n = (self.length.to_f64().unwrap() / h)
-            .ceil()
-            .to_usize()
-            .unwrap();
+        let n = ((self.length as f64) / h).ceil() as usize;
         for i in 0..n - 1 {
             let ds = self.dsdt(self.s_popf[(i, 0)], self.i_popf[(i, 0)]);
             let di = self.didt(self.s_popf[(i, 0)], self.i_popf[(i, 0)]);
@@ -234,10 +231,7 @@ impl Model {
     ///
     /// This method is suitable for general purposes.
     pub fn run_rk4(&mut self) -> &Model {
-        let n = (self.length.to_f64().unwrap() / self.step_size)
-            .ceil()
-            .to_usize()
-            .unwrap();
+        let n = (self.length as f64 / self.step_size).ceil() as usize;
         for t in 0..n - 1 {
             let k = self.rk4_step(t);
             let ds = (k[1].s + (2.0 * k[2].s) + (2.0 * k[3].s) + k[4].s) * (self.step_size / 6.0);
@@ -249,7 +243,7 @@ impl Model {
             if t % 10 == 0 {
                 println!(
                     "t={:.1} s={:.6} i={:.6} r={:.6}",
-                    t.to_f64().unwrap() * self.step_size,
+                    (t as f64) * self.step_size,
                     self.s_popf[(t, 0)],
                     self.i_popf[(t, 0)],
                     self.r_popf[(t, 0)],
@@ -263,7 +257,7 @@ impl Model {
 #[cfg(test)]
 mod tests {
     use crate::sirrs::sir::Model;
-    use faer::{Mat, traits::num_traits::ToPrimitive};
+    use faer::Mat;
 
     #[test]
     fn test_new() {
@@ -322,9 +316,7 @@ mod tests {
     fn test_configure() {
         let mut model = Model::new();
         model.configure(10, 1.0, 0.01, 0.0, 0.02, 0.03, 0.04);
-        let n_steps = (model.length.to_f64().unwrap() / model.step_size)
-            .to_usize()
-            .unwrap();
+        let n_steps = ((model.length as f64) / model.step_size).ceil() as usize;
         assert_eq!(
             model.length, 10,
             "Bad length, expected 10 got {}",
@@ -451,10 +443,7 @@ mod tests {
         model.init_popf();
         model.run_euler();
         let h = model.step_size;
-        let n = (model.length.to_f64().unwrap() / h)
-            .ceil()
-            .to_usize()
-            .unwrap();
+        let n = ((model.length as f64) / h).ceil() as usize;
         for t in 1..n - 1 {
             let dsdt = model.dsdt(model.s_popf[(t - 1, 0)], model.i_popf[(t - 1, 0)]);
             let didt = model.didt(model.s_popf[(t - 1, 0)], model.i_popf[(t - 1, 0)]);
@@ -610,10 +599,7 @@ mod tests {
         model.init_popf();
         model.run_rk4();
         let h = model.step_size;
-        let n = (model.length.to_f64().unwrap() / h)
-            .ceil()
-            .to_usize()
-            .unwrap();
+        let n = (model.length as f64 / h).ceil() as usize;
         for t in 0..n - 1 {
             let mut y = model.init_y();
             let mut k = model.init_k();


### PR DESCRIPTION
Replace all occurrences of `to_f64()` with `as f64` and all occurrences of `to_usize` with `as usize`. This removes the need for calls to `unwrap()`.